### PR TITLE
Fix JSON Serialization Error by Correctly Handling cl.Message Type

### DIFF
--- a/bangkaew.py
+++ b/bangkaew.py
@@ -1,0 +1,17 @@
+import chainlit as cl
+import openai 
+import os 
+
+
+@cl.on_message 
+async def main(message: cl.Message):
+
+    response = openai.ChatCompletion.create(
+        model = "gpt-4", 
+        messages = [
+            {"role":"system", "content":"You are helpful assistant who obsessed with Thai Bangkaew dog."}, 
+            {"role":"user", "content": message.content}, 
+        ], 
+        temperature = 1, 
+    )
+    await cl.Message(content=response['choices'][0]['message']['content']).send()

--- a/echo.py
+++ b/echo.py
@@ -1,0 +1,8 @@
+import chainlit as cl
+import openai 
+import os 
+
+
+@cl.on_message 
+async def main(message: cl.Message):
+    await cl.Message(content=message.content).send()

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ def get_gpt_output(user_message):
     return response
 
 @cl.on_message
-async def main(message : str):
-    await cl.Message(content = f"{get_gpt_output(message)['choices'][0]['message']['content']}",).send()
+async def main(message: cl.Message):
+    await cl.Message(content = f"{get_gpt_output(message.content)['choices'][0]['message']['content']}",).send()
 
 


### PR DESCRIPTION
When executing the original code, it fails with a JSON serialization error indicating that an object of type Message is not JSON serializable. The specific errors encountered are:

UI Error: Object of type Message is not JSON serializable
Console Error: TypeError: Object of type Message is not JSON serializable
The stack trace reveals that this error occurs in main.py and is related to the handling of the cl.Message object.

After reviewing the relevant ChainLit documentation ([API Reference on on_message](https://docs.chainlit.io/api-reference/on-message)), it became evident that the issue arises because the message parameter in on_message expects a cl.Message object rather than a str.

To resolve this issue, I've adjusted the code to pass cl.Message correctly, as expected by the ChainLit API.

The fix was verified locally by running the modified code. The serialization error no longer appears, and the functionality works as intended.