### PR TITLE
Fix JSON Serialization Error by Correctly Handling cl.Message Type

### DIFF
--- a/langchain_integration.py
+++ b/langchain_integration.py
@@ -16,10 +16,10 @@ def main():
     cl.user_session.set("llm_chain",llm_chain)
 
 @cl.on_message
-async def main(message : str):
+async def main(message : cl.Message):
     llm_chain = cl.user_session.get("llm_chain")
 
-    res = await llm_chain.acall(message, callbacks=[cl.AsyncLangchainCallbackHandler()])
+    res = await llm_chain.acall(message.content, callbacks=[cl.AsyncLangchainCallbackHandler()])
 
     await cl.Message(content=res["text"]).send()
 

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ def get_gpt_output(user_message):
     return response
 
 @cl.on_message
-async def main(message : str):
-    await cl.Message(content = f"{get_gpt_output(message)['choices'][0]['message']['content']}",).send()
+async def main(message: cl.Message):
+    await cl.Message(content = f"{get_gpt_output(message.content)['choices'][0]['message']['content']}",).send()
 
 


### PR DESCRIPTION
When executing the original code, it fails with a JSON serialization error indicating that an object of type Message is not JSON serializable. The specific errors encountered are:

UI Error: Object of type Message is not JSON serializable
Console Error: TypeError: Object of type Message is not JSON serializable
The stack trace reveals that this error occurs in main.py and is related to the handling of the cl.Message object.

After reviewing the relevant ChainLit documentation ([API Reference on on_message](https://docs.chainlit.io/api-reference/on-message)), it became evident that the issue arises because the message parameter in on_message expects a cl.Message object rather than a str.

To resolve this issue, I've adjusted the code to pass cl.Message correctly, as expected by the ChainLit API.

The fix was verified locally by running the modified code. The serialization error no longer appears, and the functionality works as intended.

The cl.on_message API has been updated recently, specifically 4 days ago. The function signature has been modified and it no longer accepts a string as its parameter; it now requires a cl.Message object instead.

For more details, refer to the official release notes: [ChainLit v0.7.3 Release Notes](https://github.com/Chainlit/chainlit/releases/tag/0.7.3).